### PR TITLE
Add shelter scraper identity migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 .env.local
 *.local
 *~
+supabase/.temp/
 
 # IDE
 .vscode/

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -48,6 +48,9 @@ Animal shelters, populated by scrapers.
 | `longitude` | double precision | |
 | `created_at` | timestamptz | Default `now()` |
 | `last_scraped_at` | timestamptz | |
+| `source_platform` | text | Scraper source system |
+| `external_id` | text | Source-specific shelter identifier. Unique with `source_platform` when both are set |
+| `source_url` | text | Source listing URL |
 
 ### animals
 

--- a/supabase/migrations/20260506024540_add_shelter_scraper_identity.sql
+++ b/supabase/migrations/20260506024540_add_shelter_scraper_identity.sql
@@ -1,0 +1,10 @@
+-- Add scraper identity fields to shelters.
+alter table public.shelters
+  add column if not exists source_platform text,
+  add column if not exists external_id text,
+  add column if not exists source_url text;
+
+-- Let scrapers upsert shelters by source identity while allowing manual rows.
+create unique index if not exists shelters_source_platform_external_id_key
+  on public.shelters (source_platform, external_id)
+  where source_platform is not null and external_id is not null;


### PR DESCRIPTION
## Summary
- add Supabase migration for shelter scraper identity fields
- document the new `shelters` source identity columns
- ignore local Supabase CLI temp metadata

## Verification
- confirmed `humphrey-come-home` has `source_platform`, `external_id`, and `source_url` on `public.shelters`
- confirmed `shelters_source_platform_external_id_key` exists
- confirmed Supabase migration history includes `20260506024540_add_shelter_scraper_identity`
- ran `npm run build`

## Notes
The live database already had this schema change from manual SQL. This PR records the change in repo migration history so future environments stay reproducible.